### PR TITLE
Fix UnicodeDecodeError: 'charmap' codec can't decode byte 0x81

### DIFF
--- a/scripts/anntools.py
+++ b/scripts/anntools.py
@@ -162,7 +162,7 @@ class AnnFile:
         self.annotations = []
 
     def load(self, path):
-        with open(path) as fp:
+        with open(path, encoding='utf8') as fp:
             for line in fp:
                 ann = self._parse(line)
                 if ann:


### PR DESCRIPTION
This change solves the following exception:

Traceback (most recent call last):
  File ".\scripts\baseline.py", line 120, in <module>
    main()
  File ".\scripts\baseline.py", line 115, in main
    baseline.fit(args.ref)
    collection = Collection().load_dir(path)
  File "C:\Users\User\Documents\Projects\ehealthkd\scripts\anntools.py", line 745, in load_dir
    attributes=attributes,
  File "C:\Users\User\Documents\Projects\ehealthkd\scripts\anntools.py", line 914, in load_dir
    attributes=attributes,
  File "C:\Users\User\Documents\Projects\ehealthkd\scripts\anntools.py", line 939, in load
    ann_file = cls._load_ann(finput)
  File "C:\Users\User\Documents\Projects\ehealthkd\scripts\anntools.py", line 1027, in _load_ann
    return AnnFile().load(ann_path)
  File "C:\Users\User\Documents\Projects\ehealthkd\scripts\anntools.py", line 166, in load
    for line in fp:
  File "C:\ProgramData\Anaconda3\envs\ehealthkd\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 6469: character maps to <undefined>